### PR TITLE
Fixes doubly defined label issue.

### DIFF
--- a/paper-conference-compsoc.tex
+++ b/paper-conference-compsoc.tex
@@ -294,7 +294,7 @@ The whole idea of TOSCA is explained by \citet{Binz2009}.
   % aboveskip=2.5\baselineskip,
   % belowskip=-.8\baselineskip,
   caption={Example Java Listing},
-  label=L2,
+  label=L1,
   language=Java,
   float]
 public class Hello {

--- a/paper-conference-minted.tex
+++ b/paper-conference-minted.tex
@@ -319,7 +319,7 @@ You can point to a single line: \lref{commentline}.
   % aboveskip=2.5\baselineskip,
   % belowskip=-.8\baselineskip,
   caption={Example Java Listing},
-  label=L2,
+  label=L1,
   language=Java,
   float]
 public class Hello {

--- a/paper-conference.tex
+++ b/paper-conference.tex
@@ -292,7 +292,7 @@ The whole idea of TOSCA is explained by \citet{Binz2009}.
   % aboveskip=2.5\baselineskip,
   % belowskip=-.8\baselineskip,
   caption={Example Java Listing},
-  label=L2,
+  label=L1,
   language=Java,
   float]
 public class Hello {


### PR DESCRIPTION
L1 label was missing but referenced. Changed Java listing label to L1 such that both L1 and L2 labels are present and can be found by cred.